### PR TITLE
translation into Japanese in CP932

### DIFF
--- a/resources/i18n/ja.isl
+++ b/resources/i18n/ja.isl
@@ -1,14 +1,20 @@
+[LangOptions]
+LanguageName=<65E5><672C><8A9E>
+LanguageID=$0411
+LanguageCodePage=932
+
 [Messages]
-InstallingLabel=Installing [name], this will take a few minutes...
-WelcomeLabel1=Welcome to [name]!
-WelcomeLabel2=This will install [name/ver] on your computer which includes Ruby 1.9.2, Git, Sqlite3, DevKit, Rails 3, and KidsRuby.  Please close any console applications before continuing.
-WizardLicense={#InstallerName} License Agreement
+
+InstallingLabel=[name] をインストールしています。しばらくお待ちください．．．
+WelcomeLabel1=[name]へようこそ！
+WelcomeLabel2=このコンピューターに[name/ver]をインストールします。このプログラムには、Ruby 1.9.2・Git・Sqlite3・DevKit・Rails 3・KidsRubyが含まれています。インストールを続ける前に、コンソールアプリケーションをすべて閉じてください。
+WizardLicense={#InstallerName} 使用許諾契約
 LicenseLabel=
-LicenseLabel3=Please read the following License Agreements and accept the terms before continuing the installation.
-LicenseAccepted=I &accept all of the Licenses
-LicenseNotAccepted=I &decline any of the Licenses
-WizardSelectDir=Installation Destination and Optional Tasks
-SelectDirDesc=This is the location that Ruby, DevKit, Git, Rails, Sqlite and KidsRuby will be installed to.
-SelectDirLabel3=[name] will be installed into the following folder. Click Install to continue or click Browse to use a different one.
-SelectDirBrowseLabel=Please avoid any folder name that contains spaces (e.g. Program Files).
-DiskSpaceMBLabel=Required free disk space: ~[mb] MB
+LicenseLabel3=下の使用許諾契約をお読みください。ご同意いただける場合は「同意する」を選択して、インストールを続けてください。
+LicenseAccepted=同意する(&A)
+LicenseNotAccepted=同意しない(&D)
+WizardSelectDir=インストール先とオプションの指定
+SelectDirDesc=Ruby・DevKit・Git・Rails・Sqlite・KidsRubyのインストール先の指定
+SelectDirLabel3=[name]が次のフォルダにインストールされます。継続するには「インストール」をクリックします。別のフォルダを選択するには「参照」をクリックします。
+SelectDirBrowseLabel=「Program Files」のようにスペースがあるフォルダ名を指定することはできません。
+DiskSpaceMBLabel=インストールに必要なディスクの空き容量: ~[mb] MB


### PR DESCRIPTION
ja.isl has been translated. Please pull it into ja branch.
NOTE: The installer with translated ja.isl has been reviewed under Japanese version of Windows Vista. The character code is in CP932. ja.isl in UTF-8 makes Japanese chars garbled. [LangOptions] section is added to declare code page explicitly. The reviewed package was packed by iscc came with ispack-5.5.1-unicode.exe.
